### PR TITLE
Challenge 1: Order form submit bug

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Reference to form input value via `event` is renamed from `event.value` to `event.target.value`

## Purpose
_Describe the problem or feature in addition to a link to the issues._

- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/1

- The problem was that attempting to submit the form would result in a `400` status code when passing data to the server via fetch. This was due to a bug reading form input via `event`.

## Approach
_How does this change address the problem?_

- The useState hooks were never actually updating state with form input due to incorrectly referencing `event.value`, rather than `event.target.value`. A simple renaming fixes the issue.

## Testing Steps
_How do the users test this change?_

1. Verify there is no longer a server api error after submitting a new order.
2. Navigate to `/view-orders` page to verify the new order was created.

Closes [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1)
