### PR TITLE
Challenge 3: Testing OrdersList time format display

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -9,7 +9,8 @@ const OrdersList = (props) => {
     );
 
     return orders.map(order => {
-        const createdDate = new Date(order.createdAt);
+        const timestamp = new Date(order.createdAt).toLocaleTimeString('en-US', { hour12: false });
+
         return (
             <div className="row view-order-container" key={order._id}>
                 <div className="col-md-4 view-order-left-col p-3">
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {timestamp}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,38 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('renders a single order with a midnight timestamp in proper hh:mm:ss format', () => {
+      const orders = [
+        {
+            order_item: "Pasta",
+            quantity: "1",
+            _id: 1,
+            createdAt: "2022-01-30T08:00:00.973Z"
+        },
+      ];
+      render(
+        <OrdersList
+            orders={orders}
+        />
+      )
+      expect(screen.getByText('Order placed at 24:00:00')).toBeInTheDocument();
+    })
+
+    test('renders a single order with 1:05 AM timestamp in proper hh:mm:ss format', () => {
+      const orders = [
+        {
+            order_item: "Food",
+            quantity: "35",
+            _id: 1,
+            createdAt: "2022-01-30T09:05:09.973Z"
+        },
+      ];
+      render(
+        <OrdersList
+            orders={orders}
+        />
+      )
+      expect(screen.getByText('Order placed at 01:05:09')).toBeInTheDocument();
+    });
 })


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added 2 tests to the OrdersList test suite via `ordersList.test.js`.

## Purpose
_Describe the problem or feature in addition to a link to the issues._

- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/3

## Approach
_How does this change address the problem?_

- Adds 2 tests with sample dates passed into each a single order per test, checking for particular edge cases. One with midnight exactly (expecting `24:00:00`) and 1:05 AM and 9 seconds to return `01:05:09`.

Closes https://github.com/Shift3/react-challenge-project-jan-2022/issues/3
