### PR TITLE
Challenge 4: Retrieve user from Redux and include in Order Form

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Updates the authReducer by changing the reference to `action.payload.login` to `action.payload.email`.

## Purpose
_Describe the problem or feature in addition to a link to the issues._

- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/4

## Approach
_How does this change address the problem?_

- Since login is not a valid payload which is evident by looking at the `finishLogin(...)` method in `authActions.js`, simply changing `action.payload.login` to `action.payload.email` fixes the problem.

## Testing Steps
_How do the users test this change?_

- Now when logging in on the page `/login` via the email test@test.com, you can now place an order on the page `/order` and afterward see that the newly created order will contain the string `Ordered by: test@test.com`.

Closes https://github.com/Shift3/react-challenge-project-jan-2022/issues/4
