### PR TITLE
Challenge 5:  Log Out Feature

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,8 +1,21 @@
 import React from "react";
+import { connect } from 'react-redux'; 
+import { logoutUser } from '../../redux/actions/authActions';
 import { Link } from "react-router-dom";
 import "./nav.css";
 
+const mapActionsToProps = dispatch => ({
+  commenceLogout() {
+    dispatch(logoutUser())
+  }
+})
+
 const Nav = (props) => {
+
+  const doLogout = () => {
+    props.commenceLogout();
+  }
+
     return (
         <div className="nav-strip">
             <Link to={"/order"} className="nav-link">
@@ -15,7 +28,7 @@ const Nav = (props) => {
                     <label className="nav-label">View Orders</label>
                 </div>
             </Link>
-            <Link to={"/login"} className="nav-link">
+            <Link to={"/"} onClick={doLogout} className="nav-link">
                 <div className="nav-link-style">
                     <label className="nav-label">Log Out</label>
                 </div>
@@ -24,4 +37,4 @@ const Nav = (props) => {
     );
 }
 
-export default Nav;
+export default connect(null, mapActionsToProps)(Nav);

--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. (from challenge 1) Fixes order form input by changing `event.value` to `event.target.value`
2. (from challenge 4) Fixes authReducer action payload to properly login
3. Wires in the logout button in the `nav` component.

## Purpose
_Describe the problem or feature in addition to a link to the issues._

- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/5
- The problem was that the current `nav` logout button _just_  navigates the user to the Login page. The desired functionality is to navigate to the welcome page (`/`) and actually log the user out (clear auth state).

## Approach
_How does this change address the problem?_

- I simply added an `onClick` listener to the `<Link>` element which currently just navigates the user to the Login page. Now instead it will perform the navigation to the welcome page (`/`) and call the `logoutUser()` redux action.

## Testing Steps
_How do the users test this change?_

- To verify the logout is actually working, you can add `useSelector` to `main.js` to `console.log` the state.auth object to see that the values turn to null and are populated when logged in. Otherwise, there's no real way to tell since the UI looks the same regardless of what page you're on.

Closes https://github.com/Shift3/react-challenge-project-jan-2022/issues/5
